### PR TITLE
Fix: admin_access_user route not accessible in other authenticated routes

### DIFF
--- a/resources/views/contact_page.blade.php
+++ b/resources/views/contact_page.blade.php
@@ -46,6 +46,10 @@
                         <i class="fa-regular fa-list-check"></i>
                         <a class="sidebar-link" href="{{ route('tasks') }}">Task</a>
                     </li>
+                    <li class="sidebar-item">
+                        <i class="fa-regular fa-user"></i>
+                        <a class="sidebar-link" href="{{ route('admin_access_user') }}">Users</a>
+                    </li>
                 </ul>
             </nav>
         </aside>

--- a/resources/views/leads.blade.php
+++ b/resources/views/leads.blade.php
@@ -51,6 +51,10 @@
                         <i class="fa-regular fa-list-check"></i>
                         <a class="sidebar-link" href="{{ route('tasks') }}">Task</a>
                     </li>
+                    <li class="sidebar-item">
+                        <i class="fa-regular fa-user"></i>
+                        <a class="sidebar-link" href="{{ route('admin_access_user') }}">Users</a>
+                    </li>
                 </ul>
             </nav>
         </aside>

--- a/resources/views/pipelines_page.blade.php
+++ b/resources/views/pipelines_page.blade.php
@@ -42,6 +42,10 @@
                         <i class="fa-regular fa-list-check"></i>
                         <a class="sidebar-link" href="{{ route('tasks') }}">Task</a>
                     </li>
+                    <li class="sidebar-item">
+                        <i class="fa-regular fa-user"></i>
+                        <a class="sidebar-link" href="{{ route('admin_access_user') }}">Users</a>
+                    </li>
                 </ul>
             </nav>
         </aside>

--- a/resources/views/tasks.blade.php
+++ b/resources/views/tasks.blade.php
@@ -51,6 +51,10 @@
                         <i class="fa-regular fa-list-check"></i>
                         <a class="sidebar-link" href="{{ route('tasks') }}">Task</a>
                     </li>
+                    <li class="sidebar-item">
+                        <i class="fa-regular fa-user"></i>
+                        <a class="sidebar-link" href="{{ route('admin_access_user') }}">Users</a>
+                    </li>
                 </ul>
             </nav>
         </aside>


### PR DESCRIPTION
- [x] Add the sidebar for the `admin_access_user` route in other authenticated routes like `pipelines`, `tasks`, etc.